### PR TITLE
[FEAT] 상세 프로필 관련 API

### DIFF
--- a/src/main/java/org/example/mirimilibe/comment/service/CommentService.java
+++ b/src/main/java/org/example/mirimilibe/comment/service/CommentService.java
@@ -13,6 +13,7 @@ import org.example.mirimilibe.comment.repository.CommentSummaryResponse;
 import org.example.mirimilibe.common.domain.Specialty;
 import org.example.mirimilibe.global.error.CommentErrorCode;
 import org.example.mirimilibe.global.error.MemberErrorCode;
+import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
 import org.example.mirimilibe.global.error.PostErrorCode;
 import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
@@ -47,7 +48,7 @@ public class CommentService {
 			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
 
 		MilitaryInfo info = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
 
 		// 1. 군구분 매칭

--- a/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import org.example.mirimilibe.global.auth.dto.LoginSuccessRes;
 import org.example.mirimilibe.global.auth.dto.RefreshDTO;
 import org.example.mirimilibe.global.auth.jwt.util.JwtTokenUtil;
 import org.example.mirimilibe.global.error.MemberErrorCode;
+import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
 import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
 import org.example.mirimilibe.global.auth.dto.SignUpReq;
@@ -188,7 +189,7 @@ public class AuthService {
 
 	private boolean checkMilitaryInfoInit(Long memberId) {
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
 		if (militaryInfo.getMiliStatus().equals(MiliStatus.ENLISTED)) {
 			return militaryInfo.getMiliType() != null;

--- a/src/main/java/org/example/mirimilibe/global/error/MemberErrorCode.java
+++ b/src/main/java/org/example/mirimilibe/global/error/MemberErrorCode.java
@@ -16,10 +16,6 @@ public enum MemberErrorCode implements ErrorCode{
 	ACCESS_EXPIRED(HttpStatus.BAD_REQUEST,"ACCESS401","액세스 토큰이 만료되었습니다"),
 	DUPLICATE_AUTHORIZE_CODE(HttpStatus.BAD_REQUEST,"ACCESS402","인가 코드 중복 사용"),
 	ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN,"ACCESS403","탈퇴한 회원입니다."),
-	MILITARY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404-2", "군 정보를 찾을 수 없습니다."),
-	MILITARY_INFO_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400-1", "이미 군 정보가 존재합니다."),
-	MILITARY_INFO_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "MEMBER400-2", "입력된 정보는 수정할 수 없습니다."),
-	MILITARY_INFO_CANNOT_ACCESS(HttpStatus.BAD_REQUEST, "MEMBER400-5", "군 정보에 접근할 수 없습니다."),
 
 	UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404-3", "부대를 찾을 수 없습니다."),
 	SPECIALTY_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404-4", "특기를 찾을 수 없습니다."),

--- a/src/main/java/org/example/mirimilibe/global/error/MemberErrorCode.java
+++ b/src/main/java/org/example/mirimilibe/global/error/MemberErrorCode.java
@@ -18,9 +18,11 @@ public enum MemberErrorCode implements ErrorCode{
 	ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN,"ACCESS403","탈퇴한 회원입니다."),
 	MILITARY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404-2", "군 정보를 찾을 수 없습니다."),
 	MILITARY_INFO_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400-1", "이미 군 정보가 존재합니다."),
+	MILITARY_INFO_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "MEMBER400-2", "입력된 정보는 수정할 수 없습니다."),
+	MILITARY_INFO_CANNOT_ACCESS(HttpStatus.BAD_REQUEST, "MEMBER400-5", "군 정보에 접근할 수 없습니다."),
+
 	UNIT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404-3", "부대를 찾을 수 없습니다."),
 	SPECIALTY_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404-4", "특기를 찾을 수 없습니다."),
-	MILITARY_INFO_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "MEMBER400-2", "입력된 정보는 수정할 수 없습니다."),
 
 	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND,"MATCH404","이용내역을 찾을 수 없습니다."),
 	DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "MEMBER400-3", "이미 등록된 전화번호입니다."),

--- a/src/main/java/org/example/mirimilibe/global/error/MilitaryInfoErrorCode.java
+++ b/src/main/java/org/example/mirimilibe/global/error/MilitaryInfoErrorCode.java
@@ -1,0 +1,19 @@
+package org.example.mirimilibe.global.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MilitaryInfoErrorCode implements ErrorCode{
+	MILITARY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "MILITARYINFO404", "군 정보를 찾을 수 없습니다."),
+	MILITARY_INFO_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MILITARYINFO409", "이미 군 정보가 존재합니다."),
+	MILITARY_INFO_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "MILITARYINFO400", "군 정보를 수정할 수 없습니다."),
+	MILITARY_INFO_CANNOT_ACCESS(HttpStatus.BAD_REQUEST, "MILITARYINFO403", "군 정보에 접근할 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
@@ -25,9 +25,13 @@ public class MemberController {
 
 	@PostMapping("/profile")
 	@Operation(
-		summary = "프로필 설정",
-		description = "사용자의 군 정보를 설정하는 API입니다. <br>"
-			+ "MiliType은 ENUM 타입으로, 'ARMY, NAVY, AIR_FORCE' 중 하나를 입력해주세요. 해당 필드는 필수로 입력해야 합니다."
+		summary = "프로필 설정/수정",
+		description = "사용자의 군 정보를 설정하는 API입니다. (마이페이지: 현역 사용자의 상세 프로필)<br>"
+			+ "MiliType은 ENUM 타입으로, 'ARMY, NAVY, AIR_FORCE' 중 하나를 입력해주세요. 해당 필드는 필수로 입력해야 합니다. <br>"
+			+ "이미 프로필이 존재하는 경우, 해당 API는 프로필을 수정합니다. <br>"
+			+ "- 기존값이 null이었던 필드에 새로운 값을 입력하는 것은 가능합니다. <br>"
+			+ "- 기존값이 존재하는 필드에 새로운 값을 입력하는 경우 오류를 반환합니다. <br>"
+			+ "마이페이지에서 호출하실 때는 기존 정보들을 불러오신 후, 수정하실 필드만 변경하여 보내주시면 됩니다. <br>"
 	)
 	public ResponseEntity<ApiResponse<String>> updateProfile(@Valid @RequestBody MilitaryInfoReq req, @AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
 		memberService.updateMilitaryInfo(req, jwtMemberDetail.getMemberId());

--- a/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package org.example.mirimilibe.member.controller;
 import org.example.mirimilibe.global.ApiResponse;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
 import org.example.mirimilibe.member.dto.MilitaryInfoReq;
+import org.example.mirimilibe.member.dto.MilitaryInfoRes;
 import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,6 +32,17 @@ public class MemberController {
 	public ResponseEntity<ApiResponse<String>> updateProfile(@Valid @RequestBody MilitaryInfoReq req, @AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
 		memberService.updateMilitaryInfo(req, jwtMemberDetail.getMemberId());
 		return ResponseEntity.ok(ApiResponse.success("프로필 생성 성공"));
+	}
+
+	@GetMapping("/profile")
+	@Operation(
+		summary = "프로필 조회",
+		description = "사용자의 군 정보를 조회하는 API입니다. <br>"
+			+ "아직 입력되지 않은 정보는 null로 반환됩니다."
+	)
+	public ResponseEntity<ApiResponse<MilitaryInfoRes>> getProfile(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		MilitaryInfoRes res = memberService.getMilitaryInfo(jwtMemberDetail.getMemberId());
+		return ResponseEntity.ok(ApiResponse.success(res));
 	}
 
 }

--- a/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.example.mirimilibe.member.controller;
 
+import org.example.mirimilibe.common.Enum.MiliStatus;
 import org.example.mirimilibe.global.ApiResponse;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
 import org.example.mirimilibe.member.dto.MilitaryInfoReq;
@@ -8,9 +9,11 @@ import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,12 +28,13 @@ public class MemberController {
 
 	@PostMapping("/profile")
 	@Operation(
-		summary = "프로필 설정/수정",
-		description = "사용자의 군 정보를 설정하는 API입니다. (마이페이지: 현역 사용자의 상세 프로필)<br>"
+		summary = "상세 프로필 설정/수정",
+		description = "현역 사용자의 군 정보를 설정하는 API입니다. (마이페이지: 현역 사용자의 상세 프로필)<br>"
 			+ "MiliType은 ENUM 타입으로, 'ARMY, NAVY, AIR_FORCE' 중 하나를 입력해주세요. 해당 필드는 필수로 입력해야 합니다. <br>"
 			+ "이미 프로필이 존재하는 경우, 해당 API는 프로필을 수정합니다. <br>"
 			+ "- 기존값이 null이었던 필드에 새로운 값을 입력하는 것은 가능합니다. <br>"
 			+ "- 기존값이 존재하는 필드에 새로운 값을 입력하는 경우 오류를 반환합니다. <br>"
+			+ "- 입대 전 사용자일 경우 오류를 반환합니다. <br>"
 			+ "마이페이지에서 호출하실 때는 기존 정보들을 불러오신 후, 수정하실 필드만 변경하여 보내주시면 됩니다. <br>"
 	)
 	public ResponseEntity<ApiResponse<String>> updateProfile(@Valid @RequestBody MilitaryInfoReq req, @AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
@@ -47,6 +51,17 @@ public class MemberController {
 	public ResponseEntity<ApiResponse<MilitaryInfoRes>> getProfile(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
 		MilitaryInfoRes res = memberService.getMilitaryInfo(jwtMemberDetail.getMemberId());
 		return ResponseEntity.ok(ApiResponse.success(res));
+	}
+
+	@PatchMapping("/milistatus")
+	@Operation(
+		summary = "입대 전 -> 현역 변경",
+		description = "입대 전 사용자의 MiliStatus를 현역으로 변경하는 API입니다. <br>"
+			+ "요청한 사용자의 현 상태가 PRE_ENLISTED가 아닐 경우 오류를 반환합니다. <br>"
+	)
+	public ResponseEntity<ApiResponse<String>> changeMiliStatus(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		memberService.updateMiliStatus(jwtMemberDetail.getMemberId());
+		return ResponseEntity.ok(ApiResponse.success("군 상태 변경 성공"));
 	}
 
 }

--- a/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import org.example.mirimilibe.global.ApiResponse;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
 import org.example.mirimilibe.member.dto.MilitaryInfoReq;
 import org.example.mirimilibe.member.dto.MilitaryInfoRes;
+import org.example.mirimilibe.member.dto.MyPageRes;
 import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,14 +43,14 @@ public class MemberController {
 		return ResponseEntity.ok(ApiResponse.success("프로필 생성 성공"));
 	}
 
-	@GetMapping("/profile")
+	@GetMapping("/mypage")
 	@Operation(
-		summary = "프로필 조회",
-		description = "사용자의 군 정보를 조회하는 API입니다. <br>"
+		summary = "마이페이지 정보 조회",
+		description = "사용자의 기본 정보, 군 정보를 조회하는 API입니다. <br>"
 			+ "아직 입력되지 않은 정보는 null로 반환됩니다."
 	)
-	public ResponseEntity<ApiResponse<MilitaryInfoRes>> getProfile(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
-		MilitaryInfoRes res = memberService.getMilitaryInfo(jwtMemberDetail.getMemberId());
+	public ResponseEntity<ApiResponse<MyPageRes>> getProfile(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		MyPageRes res = memberService.getMilitaryInfo(jwtMemberDetail.getMemberId());
 		return ResponseEntity.ok(ApiResponse.success(res));
 	}
 

--- a/src/main/java/org/example/mirimilibe/member/dto/MilitaryInfoRes.java
+++ b/src/main/java/org/example/mirimilibe/member/dto/MilitaryInfoRes.java
@@ -1,0 +1,33 @@
+package org.example.mirimilibe.member.dto;
+
+import java.time.LocalDate;
+
+import org.example.mirimilibe.common.Enum.MiliStatus;
+import org.example.mirimilibe.common.Enum.MiliType;
+import org.example.mirimilibe.member.domain.MilitaryInfo;
+
+public record MilitaryInfoRes(
+	MiliStatus status,
+	MiliType type,
+	Long specialtyId,
+	Long unitId,
+	LocalDate startDate,
+	LocalDate privateDate,
+	LocalDate corporalDate,
+	LocalDate sergeantDate,
+	LocalDate dischargeDate
+) {
+	public static MilitaryInfoRes fromEntity(MilitaryInfo militaryInfo){
+		return new MilitaryInfoRes(
+			militaryInfo.getMiliStatus(),
+			militaryInfo.getMiliType(),
+			militaryInfo.getSpecialty()!=null ? militaryInfo.getSpecialty().getId() : null,
+			militaryInfo.getUnit()!=null ? militaryInfo.getUnit().getId() : null,
+			militaryInfo.getStartDate(),
+			militaryInfo.getPrivateDate(),
+			militaryInfo.getCorporalDate(),
+			militaryInfo.getSergeantDate(),
+			militaryInfo.getDischargeDate()
+		);
+	}
+}

--- a/src/main/java/org/example/mirimilibe/member/dto/MilitaryInfoRes.java
+++ b/src/main/java/org/example/mirimilibe/member/dto/MilitaryInfoRes.java
@@ -7,7 +7,6 @@ import org.example.mirimilibe.common.Enum.MiliType;
 import org.example.mirimilibe.member.domain.MilitaryInfo;
 
 public record MilitaryInfoRes(
-	MiliStatus status,
 	MiliType type,
 	Long specialtyId,
 	Long unitId,
@@ -19,7 +18,6 @@ public record MilitaryInfoRes(
 ) {
 	public static MilitaryInfoRes fromEntity(MilitaryInfo militaryInfo){
 		return new MilitaryInfoRes(
-			militaryInfo.getMiliStatus(),
 			militaryInfo.getMiliType(),
 			militaryInfo.getSpecialty()!=null ? militaryInfo.getSpecialty().getId() : null,
 			militaryInfo.getUnit()!=null ? militaryInfo.getUnit().getId() : null,

--- a/src/main/java/org/example/mirimilibe/member/dto/MyPageRes.java
+++ b/src/main/java/org/example/mirimilibe/member/dto/MyPageRes.java
@@ -1,0 +1,14 @@
+package org.example.mirimilibe.member.dto;
+
+import org.example.mirimilibe.common.Enum.MiliStatus;
+
+public record MyPageRes (
+	MiliStatus status,
+	String nickname,
+	String phoneNumber,
+	MilitaryInfoRes militaryInfo
+){
+	public static MyPageRes of(MiliStatus status, String nickname, String phoneNumber, MilitaryInfoRes militaryInfo) {
+		return new MyPageRes(status, nickname, phoneNumber, militaryInfo);
+	}
+}

--- a/src/main/java/org/example/mirimilibe/member/service/MemberService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MemberService.java
@@ -8,6 +8,7 @@ import org.example.mirimilibe.common.Enum.MiliStatus;
 import org.example.mirimilibe.common.domain.Specialty;
 import org.example.mirimilibe.common.domain.Unit;
 import org.example.mirimilibe.global.error.MemberErrorCode;
+import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
 import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
 import org.example.mirimilibe.member.domain.MilitaryInfo;
@@ -34,7 +35,7 @@ public class MemberService {
 	public void createMilitaryInfo(MiliStatus miliStatus, Member member) {
 		// 1. MilitaryInfo가 이미 존재하는지 확인
 		if (militaryInfoRepository.existsByMemberId(member.getId())) {
-			throw new MiriMiliException(MemberErrorCode.MILITARY_INFO_ALREADY_EXISTS);
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_ALREADY_EXISTS);
 		}
 
 		// 2. MilitaryInfo 객체 생성
@@ -50,10 +51,10 @@ public class MemberService {
 	public void updateMilitaryInfo(MilitaryInfoReq militaryInfoReq, Long memberId) {
 		// 1. MilitaryInfo 객체 조회
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
 		if(militaryInfo.getMiliStatus() == MiliStatus.PRE_ENLISTED) {
-			throw new MiriMiliException(MemberErrorCode.MILITARY_INFO_CANNOT_ACCESS);
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_ACCESS);
 		}
 
 		Specialty specialty = Optional.ofNullable(militaryInfoReq.specialtyId())
@@ -73,17 +74,17 @@ public class MemberService {
 
 	public MilitaryInfoRes getMilitaryInfo(Long memberId) {
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
 		return MilitaryInfoRes.fromEntity(militaryInfo);
 	}
 
 	public void updateMiliStatus(Long memberId) {
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
 		if(militaryInfo.getMiliStatus() != MiliStatus.PRE_ENLISTED) {
-			throw new MiriMiliException(MemberErrorCode.MILITARY_INFO_CANNOT_UPDATE);
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_UPDATE);
 		}
 
 		militaryInfo.setMiliStatus(MiliStatus.ENLISTED);
@@ -109,7 +110,7 @@ public class MemberService {
 		if (currentValue == null) {
 			setter.accept(newValue);
 		} else if (!currentValue.equals(newValue)) {
-			throw new MiriMiliException(MemberErrorCode.MILITARY_INFO_CANNOT_UPDATE);
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_UPDATE);
 		}
 	}
 

--- a/src/main/java/org/example/mirimilibe/member/service/MemberService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MemberService.java
@@ -52,6 +52,10 @@ public class MemberService {
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
 			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
 
+		if(militaryInfo.getMiliStatus() == MiliStatus.PRE_ENLISTED) {
+			throw new MiriMiliException(MemberErrorCode.MILITARY_INFO_CANNOT_ACCESS);
+		}
+
 		Specialty specialty = Optional.ofNullable(militaryInfoReq.specialtyId())
 			.flatMap(specialtyRepository::findById)
 			.orElse(null);
@@ -72,6 +76,19 @@ public class MemberService {
 			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
 
 		return MilitaryInfoRes.fromEntity(militaryInfo);
+	}
+
+	public void updateMiliStatus(Long memberId) {
+		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+
+		if(militaryInfo.getMiliStatus() != MiliStatus.PRE_ENLISTED) {
+			throw new MiriMiliException(MemberErrorCode.MILITARY_INFO_CANNOT_UPDATE);
+		}
+
+		militaryInfo.setMiliStatus(MiliStatus.ENLISTED);
+
+		militaryInfoRepository.save(militaryInfo);
 	}
 
 	public void applyImmutableFields(MilitaryInfo info, MilitaryInfoReq req, Specialty specialty, Unit unit) {

--- a/src/main/java/org/example/mirimilibe/member/service/MemberService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MemberService.java
@@ -14,6 +14,7 @@ import org.example.mirimilibe.member.domain.Member;
 import org.example.mirimilibe.member.domain.MilitaryInfo;
 import org.example.mirimilibe.member.dto.MilitaryInfoReq;
 import org.example.mirimilibe.member.dto.MilitaryInfoRes;
+import org.example.mirimilibe.member.dto.MyPageRes;
 import org.example.mirimilibe.member.repository.MemberRepository;
 import org.example.mirimilibe.member.repository.MilitaryInfoRepository;
 import org.example.mirimilibe.member.repository.UnitRepository;
@@ -72,11 +73,16 @@ public class MemberService {
 		militaryInfoRepository.save(militaryInfo);
 	}
 
-	public MilitaryInfoRes getMilitaryInfo(Long memberId) {
+	public MyPageRes getMilitaryInfo(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
+
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
 			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
-		return MilitaryInfoRes.fromEntity(militaryInfo);
+		MilitaryInfoRes militaryInfoRes=MilitaryInfoRes.fromEntity(militaryInfo);
+
+		return MyPageRes.of(militaryInfo.getMiliStatus(), member.getNickname(), member.getNumber(), militaryInfoRes);
 	}
 
 	public void updateMiliStatus(Long memberId) {

--- a/src/main/java/org/example/mirimilibe/member/service/MemberService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MemberService.java
@@ -12,6 +12,7 @@ import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
 import org.example.mirimilibe.member.domain.MilitaryInfo;
 import org.example.mirimilibe.member.dto.MilitaryInfoReq;
+import org.example.mirimilibe.member.dto.MilitaryInfoRes;
 import org.example.mirimilibe.member.repository.MemberRepository;
 import org.example.mirimilibe.member.repository.MilitaryInfoRepository;
 import org.example.mirimilibe.member.repository.UnitRepository;
@@ -64,6 +65,13 @@ public class MemberService {
 
 		// 3. MilitaryInfo 저장
 		militaryInfoRepository.save(militaryInfo);
+	}
+
+	public MilitaryInfoRes getMilitaryInfo(Long memberId) {
+		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+
+		return MilitaryInfoRes.fromEntity(militaryInfo);
 	}
 
 	public void applyImmutableFields(MilitaryInfo info, MilitaryInfoReq req, Specialty specialty, Unit unit) {

--- a/src/main/java/org/example/mirimilibe/post/service/PostService.java
+++ b/src/main/java/org/example/mirimilibe/post/service/PostService.java
@@ -11,6 +11,7 @@ import org.example.mirimilibe.common.domain.Category;
 import org.example.mirimilibe.common.domain.Specialty;
 import org.example.mirimilibe.global.CommonPageResponse;
 import org.example.mirimilibe.global.error.MemberErrorCode;
+import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
 import org.example.mirimilibe.global.error.PostErrorCode;
 import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
@@ -95,7 +96,7 @@ public class PostService {
 
 		Member writer = post.getWriter();
 		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(writer.getId())
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MILITARY_INFO_NOT_FOUND));
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
 
 		// 카테고리 이름 추출
 		List<String> categoryNames = postCategoryRepository.findAllByPost(post).stream()


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #32 

## ✨ PR 세부 내용

**마이 페이지 정보 조회 API**
GET /member/mypage

**상세 프로필 설정/수정 API**
POST /member/profile
기존 프로필 설정과 로직이 동일하여 API 그대로 사용
- 기존값이 null이었던 필드에 새로운 값을 입력하는 것은 가능
- 기존값이 존재하는 필드에 새로운 값을 입력하는 경우 오류 반환

-> 마이페이지에서 호출할 경우, 기존 정보들을 불러온 후 수정할 필드만 변경하여 요청

**입대 전 사용자 현역 상태로 변환 API**
PATCH /member/milistatus
<img width="1117" height="502" alt="image" src="https://github.com/user-attachments/assets/f88340c7-fd94-4a67-a604-21e5046a129e" />
- 위 사진의 변경 버튼에 사용되는 API
- 요청한 사용자의 MiliStatus가 PRE_ENLISTED가 아닐 경우 예외처리

<!-- 수정/추가한 내용을 적어주세요. -->