### PR TITLE
[FEAT] 회원탈퇴 API

### DIFF
--- a/src/main/java/org/example/mirimilibe/global/auth/controller/AuthController.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/controller/AuthController.java
@@ -33,22 +33,6 @@ public class AuthController {
 
 	private final AuthService authService;
 
-	@PostMapping("/signup")
-	@Operation(
-		summary = "회원가입",
-		description = "회원가입 API입니다. 아래 정보를 입력받습니다.<br>"
-			+ "- 전화번호: 01011112222 형식, 11자리 숫자 (필수)<br>"
-			+ "- 비밀번호: 문자열, 공백 불가 (필수)<br>"
-			+ "- 닉네임: 문자열, 공백 불가 (필수)<br>"
-			+ "- serviceAgreed, privacyPolicyAgreed, marketingConsentAgreed: 약관 동의 여부, service와 privacy는 true여야 함 (필수)<br>"
-			+ "- MiliStatus: ENUM 타입, 'PRE_ENLISTED, ENLISTED, DISCHARGED' 중 하나 (필수)<br>"
-			+ "모든 필드는 필수로 입력해야 합니다."
-	)
-	public ResponseEntity<ApiResponse<?>> signUp(@RequestBody @Valid SignUpReq signUpReq) {
-		authService.signUp(signUpReq);
-		return ResponseEntity.ok(ApiResponse.success("회원가입이 완료되었습니다."));
-	}
-
 	@PostMapping("/login")
 	@Operation(
 		summary = "로그인",

--- a/src/main/java/org/example/mirimilibe/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -73,7 +73,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		//5. SecurityContext에 인증 정보 저장
 		try {
 			authentication = jwtTokenUtil.getAuthentication(accessToken);
-			log.info("인증된 사용자: {}", authentication.getName());
 
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 			response.setHeader("Authorization", GRANT_TYPE + accessToken);

--- a/src/main/java/org/example/mirimilibe/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected List<String> filterPassList=List.of(
 		"/auth/login",
 		"/actuator/prometheus",
-		"/auth/signup",
+		"/member/signup",
 		"/auth/checkNickname",
 		"/swagger-ui/**",
 		"/swagger-resources/**",

--- a/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
@@ -37,6 +37,13 @@ public class AuthService {
 
 	@Transactional
 	public LoginSuccessRes login(LoginReq loginReq) {
+		// 0. 전화번호로 회원 조회
+		Member member = memberRepository.findByNumber(loginReq.phoneNumber())
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		if(member.getStatus() == Status.INACTIVE) {
+			throw new MiriMiliException(MemberErrorCode.ACCESS_FORBIDDEN);
+		}
 
 		// 1. 인증 시도
 		Authentication authentication;
@@ -51,14 +58,6 @@ public class AuthService {
 
 		// 2. 인증된 사용자 정보 추출
 		JwtMemberDetail userDetails = (JwtMemberDetail)authentication.getPrincipal();
-		Long memberId = userDetails.getMemberId();
-
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-		if (member.getStatus() == Status.INACTIVE) {
-			throw new MiriMiliException(MemberErrorCode.ACCESS_FORBIDDEN);
-		}
 
 		// 3. JWT 생성
 		Authentication newAuth = jwtTokenUtil.createAuthentication(member);
@@ -70,7 +69,7 @@ public class AuthService {
 		member.updateRefreshToken(refreshToken);
 
 		//4-1. 현역 여부 및 군 정보 초기화 여부 확인
-		boolean isMilitaryInfoInit = checkMilitaryInfoInit(memberId);
+		boolean isMilitaryInfoInit = checkMilitaryInfoInit(userDetails.getMemberId());
 
 		// 5. 결과 반환
 		return LoginSuccessRes.of(accessToken, refreshToken, member.getNickname(), isMilitaryInfoInit);

--- a/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
@@ -1,36 +1,23 @@
 package org.example.mirimilibe.global.auth.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
-
 import org.example.mirimilibe.common.Enum.MiliStatus;
 import org.example.mirimilibe.common.Enum.Status;
-import org.example.mirimilibe.common.Enum.TermType;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
 import org.example.mirimilibe.global.auth.dto.LoginReq;
 import org.example.mirimilibe.global.auth.dto.LoginSuccessRes;
 import org.example.mirimilibe.global.auth.dto.RefreshDTO;
 import org.example.mirimilibe.global.auth.jwt.util.JwtTokenUtil;
 import org.example.mirimilibe.global.error.MemberErrorCode;
-import org.example.mirimilibe.global.error.SmsErrorCode;
 import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
 import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
-import org.example.mirimilibe.global.auth.dto.SignUpReq;
-import org.example.mirimilibe.member.domain.MemberTerm;
 import org.example.mirimilibe.member.domain.MilitaryInfo;
 import org.example.mirimilibe.member.repository.MemberRepository;
-import org.example.mirimilibe.member.repository.MemberTermRepository;
 import org.example.mirimilibe.member.repository.MilitaryInfoRepository;
-import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,63 +29,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 	private final MemberRepository memberRepository;
-	private final BCryptPasswordEncoder passwordEncoder;
 	private final AuthenticationManager authenticationManager;
 	private final JwtTokenUtil jwtTokenUtil;
-	private final MemberService memberService;
-	private final MemberTermRepository memberTermRepository;
 	private final MilitaryInfoRepository militaryInfoRepository;
 	private final BlackListService blackListService;
 
-	public void signUp(SignUpReq signUpReq) {
-		//0. 문자 인증 여부 조회
-		/*if( !coolSmsService.isCertificationCompleted(signUpReq.phoneNumber()) ) {
-			throw new MiriMiliException(SmsErrorCode.NEED_SMS_VERIFICATION);
-		}*/
-
-		//1. 약관 동의 검사
-		if (!signUpReq.serviceAgreed() || !signUpReq.privacyPolicyAgreed()) {
-			throw new MiriMiliException(MemberErrorCode.INVALID_MEMBER_PARAMETER);
-		}
-
-		checkDuplicatePhoneNumber(signUpReq.phoneNumber());
-		checkDuplicateNickname(signUpReq.nickname());
-
-		//2. 비밀번호 암호화
-		String encodedPassword = passwordEncoder.encode(signUpReq.password());
-
-		LocalDateTime now = LocalDateTime.now();
-
-		Member member = Member.builder()
-			.number(signUpReq.phoneNumber())
-			.password(encodedPassword)
-			.nickname(signUpReq.nickname())
-			.status(Status.ACTIVE)
-			.createdAt(now)
-			.build();
-
-		//3. 회원 정보 저장
-		memberRepository.save(member);
-
-		//4. 약관 동의 정보 저장
-		List<MemberTerm> memberTerms = Stream.of(
-				TermType.SERVICE,
-				TermType.PRIVACY,
-				signUpReq.marketingConsentAgreed() ? TermType.MARKETING : null)
-			.filter(Objects::nonNull)
-			.map(type -> MemberTerm.builder()
-				.member(member)
-				.termType(type)
-				.agreedAt(now)
-				.build())
-			.toList();
-
-		memberTermRepository.saveAll(memberTerms);
-
-		//5. 군 정보 생성
-		memberService.createMilitaryInfo(signUpReq.miliStatus(), member);
-
-	}
 
 	@Transactional
 	public LoginSuccessRes login(LoginReq loginReq) {
@@ -187,12 +122,6 @@ public class AuthService {
 		blackListService.addBlacklist(accessToken);
 
 		log.info("로그아웃 성공: 사용자 ID={}", memberId);
-	}
-
-	public void checkDuplicatePhoneNumber(String phoneNumber) {
-		if (memberRepository.existsByNumber(phoneNumber)) {
-			throw new MiriMiliException(MemberErrorCode.DUPLICATE_PHONE_NUMBER);
-		}
 	}
 
 	public void checkDuplicateNickname(String nickname) {

--- a/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/service/AuthService.java
@@ -26,6 +26,7 @@ import org.example.mirimilibe.member.repository.MemberTermRepository;
 import org.example.mirimilibe.member.repository.MilitaryInfoRepository;
 import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -101,42 +102,44 @@ public class AuthService {
 
 	@Transactional
 	public LoginSuccessRes login(LoginReq loginReq) {
+
+		// 1. 인증 시도
+		Authentication authentication;
+
 		try {
-			// 1. 인증 시도
-			Authentication authentication = authenticationManager.authenticate(
-				new UsernamePasswordAuthenticationToken(
-					loginReq.phoneNumber(),
-					loginReq.password()
-				)
+			authentication = authenticationManager.authenticate(
+				new UsernamePasswordAuthenticationToken(loginReq.phoneNumber(), loginReq.password())
 			);
-
-			// 2. 인증된 사용자 정보 추출
-			JwtMemberDetail userDetails = (JwtMemberDetail)authentication.getPrincipal();
-			Long memberId = userDetails.getMemberId();
-
-			Member member = memberRepository.findById(memberId)
-				.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-			// 3. JWT 생성
-			Authentication newAuth = jwtTokenUtil.createAuthentication(member);
-			String accessToken = jwtTokenUtil.generateAccessToken(newAuth);
-			String refreshToken = jwtTokenUtil.generateRefreshToken(newAuth);
-
-			// 4. 로그인 성공 로그
-			log.info("로그인 성공: 전화번호={}, 사용자 ID={}", loginReq.phoneNumber(), member.getId());
-			member.updateRefreshToken(refreshToken);
-
-			//4-1. 현역 여부 및 군 정보 초기화 여부 확인
-			boolean isMilitaryInfoInit = checkMilitaryInfoInit(memberId);
-
-			// 5. 결과 반환
-			return LoginSuccessRes.of(accessToken, refreshToken, member.getNickname(), isMilitaryInfoInit);
+		} catch (BadCredentialsException e) {
+			throw new MiriMiliException(MemberErrorCode.PASSWORD_MISMATCH);
 		}
-		catch (Exception e) {
-			// 인증 실패 시 예외 처리
-			log.warn("로그인 실패: 전화번호={}, {}", loginReq.phoneNumber(), e.getMessage());
-			throw new MiriMiliException(MemberErrorCode.INVALID_MEMBER_PARAMETER);
+
+		// 2. 인증된 사용자 정보 추출
+		JwtMemberDetail userDetails = (JwtMemberDetail)authentication.getPrincipal();
+		Long memberId = userDetails.getMemberId();
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		if (member.getStatus() == Status.INACTIVE) {
+			throw new MiriMiliException(MemberErrorCode.ACCESS_FORBIDDEN);
 		}
+
+		// 3. JWT 생성
+		Authentication newAuth = jwtTokenUtil.createAuthentication(member);
+		String accessToken = jwtTokenUtil.generateAccessToken(newAuth);
+		String refreshToken = jwtTokenUtil.generateRefreshToken(newAuth);
+
+		// 4. 로그인 성공 로그
+		log.info("로그인 성공: 전화번호={}, 사용자 ID={}", loginReq.phoneNumber(), member.getId());
+		member.updateRefreshToken(refreshToken);
+
+		//4-1. 현역 여부 및 군 정보 초기화 여부 확인
+		boolean isMilitaryInfoInit = checkMilitaryInfoInit(memberId);
+
+		// 5. 결과 반환
+		return LoginSuccessRes.of(accessToken, refreshToken, member.getNickname(), isMilitaryInfoInit);
+
 	}
 
 	@Transactional

--- a/src/main/java/org/example/mirimilibe/global/auth/service/BlackListService.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/service/BlackListService.java
@@ -1,5 +1,6 @@
 package org.example.mirimilibe.global.auth.service;
 
+import java.time.Duration;
 import java.util.Date;
 
 import org.example.mirimilibe.global.auth.jwt.util.JwtTokenUtil;
@@ -25,7 +26,7 @@ public class BlackListService {
 		long remainingExpiration = expiration.getTime() - now;
 
 		if (remainingExpiration > 0) { // 남은 만료시간만큼 블랙리스트로 등록
-			stringRedisTemplate.opsForValue().set(key, "logout", remainingExpiration);
+			stringRedisTemplate.opsForValue().set(key, "logout",  Duration.ofMillis(remainingExpiration));
 		}
 
 	}

--- a/src/main/java/org/example/mirimilibe/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/mirimilibe/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
 			.cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/auth/signup", "/auth/login", "/auth/checkNickname", "/auth/reissue",
+				.requestMatchers("/member/signup", "/auth/login", "/auth/checkNickname", "/auth/reissue",
 					"/sms/verify", "/sms/send", "/sms/send-pwd", "/member/password").permitAll()
 				.requestMatchers("/actuator/health",
 					"/actuator/prometheus","/swagger", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll() // Swagger 허용

--- a/src/main/java/org/example/mirimilibe/global/error/MemberErrorCode.java
+++ b/src/main/java/org/example/mirimilibe/global/error/MemberErrorCode.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode implements ErrorCode{
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "멤버를 찾을 수 없습니다."),
 	INVALID_MEMBER_PARAMETER(HttpStatus.BAD_REQUEST, "MEMBER400", "유효하지 않는 멤버입니다"),
+	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "MEMBER401", "비밀번호가 일치하지 않습니다."),
 
 	REFRESH_EXPIRED(HttpStatus.BAD_REQUEST, "ACCESS401", "리프레시 토큰이 만료되었습니다."),
 	ACCESS_TOKEN_NOT_FOUND(HttpStatus.FORBIDDEN,"ACCESS400","액세스 토큰이 없습니다."),

--- a/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
@@ -2,9 +2,9 @@ package org.example.mirimilibe.member.controller;
 
 import org.example.mirimilibe.global.ApiResponse;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
+import org.example.mirimilibe.global.auth.service.AuthService;
 import org.example.mirimilibe.member.dto.MilitaryInfoReq;
 import org.example.mirimilibe.member.dto.PwdReq;
-import org.example.mirimilibe.member.dto.MilitaryInfoRes;
 import org.example.mirimilibe.member.dto.MyPageRes;
 import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberController {
 	private final MemberService memberService;
+	private final AuthService authService;
 
 	@PostMapping("/profile")
 	@Operation(
@@ -77,6 +78,17 @@ public class MemberController {
 	public ResponseEntity<ApiResponse<String>> changeMiliStatus(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
 		memberService.updateMiliStatus(jwtMemberDetail.getMemberId());
 		return ResponseEntity.ok(ApiResponse.success("군 상태 변경 성공"));
+	}
+
+	@PatchMapping("/delete")
+	@Operation(
+		summary = "회원 탈퇴",
+		description = "로그인한 사용자의 회원 탈퇴를 처리하는 API입니다. <br>"
+			+ "회원 탈퇴 시 사용자의 전화번호를 유지하여 재가입을 방지합니다. <br>"
+	)
+	public ResponseEntity<ApiResponse<String>> deleteMember(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		memberService.deleteMember(jwtMemberDetail.getMemberId());
+		return ResponseEntity.ok(ApiResponse.success("회원 탈퇴 성공"));
 	}
 
 }

--- a/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MemberController.java
@@ -2,14 +2,12 @@ package org.example.mirimilibe.member.controller;
 
 import org.example.mirimilibe.global.ApiResponse;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
+import org.example.mirimilibe.global.auth.dto.SignUpReq;
 import org.example.mirimilibe.global.auth.service.AuthService;
-import org.example.mirimilibe.member.dto.MilitaryInfoReq;
 import org.example.mirimilibe.member.dto.PwdReq;
-import org.example.mirimilibe.member.dto.MyPageRes;
 import org.example.mirimilibe.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,20 +26,20 @@ public class MemberController {
 	private final MemberService memberService;
 	private final AuthService authService;
 
-	@PostMapping("/profile")
+	@PostMapping("/signup")
 	@Operation(
-		summary = "상세 프로필 설정/수정",
-		description = "현역 사용자의 군 정보를 설정하는 API입니다. (마이페이지: 현역 사용자의 상세 프로필)<br>"
-			+ "MiliType은 ENUM 타입으로, 'ARMY, NAVY, AIR_FORCE' 중 하나를 입력해주세요. 해당 필드는 필수로 입력해야 합니다. <br>"
-			+ "이미 프로필이 존재하는 경우, 해당 API는 프로필을 수정합니다. <br>"
-			+ "- 기존값이 null이었던 필드에 새로운 값을 입력하는 것은 가능합니다. <br>"
-			+ "- 기존값이 존재하는 필드에 새로운 값을 입력하는 경우 오류를 반환합니다. <br>"
-			+ "- 입대 전 사용자일 경우 오류를 반환합니다. <br>"
-			+ "마이페이지에서 호출하실 때는 기존 정보들을 불러오신 후, 수정하실 필드만 변경하여 보내주시면 됩니다. <br>"
+		summary = "회원가입",
+		description = "회원가입 API입니다. 아래 정보를 입력받습니다.<br>"
+			+ "- 전화번호: 01011112222 형식, 11자리 숫자 (필수)<br>"
+			+ "- 비밀번호: 문자열, 공백 불가 (필수)<br>"
+			+ "- 닉네임: 문자열, 공백 불가 (필수)<br>"
+			+ "- serviceAgreed, privacyPolicyAgreed, marketingConsentAgreed: 약관 동의 여부, service와 privacy는 true여야 함 (필수)<br>"
+			+ "- MiliStatus: ENUM 타입, 'PRE_ENLISTED, ENLISTED, DISCHARGED' 중 하나 (필수)<br>"
+			+ "모든 필드는 필수로 입력해야 합니다."
 	)
-	public ResponseEntity<ApiResponse<String>> updateProfile(@Valid @RequestBody MilitaryInfoReq req, @AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
-		memberService.updateMilitaryInfo(req, jwtMemberDetail.getMemberId());
-		return ResponseEntity.ok(ApiResponse.success("프로필 생성 성공"));
+	public ResponseEntity<ApiResponse<?>> signUp(@RequestBody @Valid SignUpReq signUpReq) {
+		memberService.signUp(signUpReq);
+		return ResponseEntity.ok(ApiResponse.success("회원가입이 완료되었습니다."));
 	}
 
 	@PatchMapping("/password")
@@ -58,36 +56,18 @@ public class MemberController {
 		return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다."));
 	}
 
-	@GetMapping("/mypage")
-	@Operation(
-		summary = "마이페이지 정보 조회",
-		description = "사용자의 기본 정보, 군 정보를 조회하는 API입니다. <br>"
-			+ "아직 입력되지 않은 정보는 null로 반환됩니다."
-	)
-	public ResponseEntity<ApiResponse<MyPageRes>> getProfile(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
-		MyPageRes res = memberService.getMilitaryInfo(jwtMemberDetail.getMemberId());
-		return ResponseEntity.ok(ApiResponse.success(res));
-	}
-
-	@PatchMapping("/milistatus")
-	@Operation(
-		summary = "입대 전 -> 현역 변경",
-		description = "입대 전 사용자의 MiliStatus를 현역으로 변경하는 API입니다. <br>"
-			+ "요청한 사용자의 현 상태가 PRE_ENLISTED가 아닐 경우 오류를 반환합니다. <br>"
-	)
-	public ResponseEntity<ApiResponse<String>> changeMiliStatus(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
-		memberService.updateMiliStatus(jwtMemberDetail.getMemberId());
-		return ResponseEntity.ok(ApiResponse.success("군 상태 변경 성공"));
-	}
 
 	@PatchMapping("/delete")
 	@Operation(
 		summary = "회원 탈퇴",
 		description = "로그인한 사용자의 회원 탈퇴를 처리하는 API입니다. <br>"
 			+ "회원 탈퇴 시 사용자의 전화번호를 유지하여 재가입을 방지합니다. <br>"
+			+ "해당 사용자는 회원 탈퇴 후 로그아웃 처리됩니다. <br>"
 	)
-	public ResponseEntity<ApiResponse<String>> deleteMember(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+	public ResponseEntity<ApiResponse<String>> deleteMember(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail,
+		@RequestHeader("Authorization") String authorizationHeader) {
 		memberService.deleteMember(jwtMemberDetail.getMemberId());
+		authService.logout(jwtMemberDetail.getMemberId(), authorizationHeader);
 		return ResponseEntity.ok(ApiResponse.success("회원 탈퇴 성공"));
 	}
 

--- a/src/main/java/org/example/mirimilibe/member/controller/MilitaryInfoController.java
+++ b/src/main/java/org/example/mirimilibe/member/controller/MilitaryInfoController.java
@@ -1,0 +1,51 @@
+package org.example.mirimilibe.member.controller;
+
+import org.example.mirimilibe.global.ApiResponse;
+import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
+import org.example.mirimilibe.member.dto.MilitaryInfoReq;
+import org.example.mirimilibe.member.service.MilitaryInfoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MilitaryInfoController {
+	private final MilitaryInfoService militaryInfoService;
+
+	@PostMapping("/profile")
+	@Operation(
+		summary = "상세 프로필 설정/수정",
+		description = "현역 사용자의 군 정보를 설정하는 API입니다. (마이페이지: 현역 사용자의 상세 프로필)<br>"
+			+ "MiliType은 ENUM 타입으로, 'ARMY, NAVY, AIR_FORCE' 중 하나를 입력해주세요. 해당 필드는 필수로 입력해야 합니다. <br>"
+			+ "이미 프로필이 존재하는 경우, 해당 API는 프로필을 수정합니다. <br>"
+			+ "- 기존값이 null이었던 필드에 새로운 값을 입력하는 것은 가능합니다. <br>"
+			+ "- 기존값이 존재하는 필드에 새로운 값을 입력하는 경우 오류를 반환합니다. <br>"
+			+ "- 입대 전 사용자일 경우 오류를 반환합니다. <br>"
+			+ "마이페이지에서 호출하실 때는 기존 정보들을 불러오신 후, 수정하실 필드만 변경하여 보내주시면 됩니다. <br>"
+	)
+	public ResponseEntity<ApiResponse<String>> updateProfile(@Valid @RequestBody MilitaryInfoReq req, @AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		militaryInfoService.updateMilitaryInfo(req, jwtMemberDetail.getMemberId());
+		return ResponseEntity.ok(ApiResponse.success("프로필 생성 성공"));
+	}
+
+	@PatchMapping("/milistatus")
+	@Operation(
+		summary = "입대 전 -> 현역 변경",
+		description = "입대 전 사용자의 MiliStatus를 현역으로 변경하는 API입니다. <br>"
+			+ "요청한 사용자의 현 상태가 PRE_ENLISTED가 아닐 경우 오류를 반환합니다. <br>"
+	)
+	public ResponseEntity<ApiResponse<String>> changeMiliStatus(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		militaryInfoService.updateMiliStatus(jwtMemberDetail.getMemberId());
+		return ResponseEntity.ok(ApiResponse.success("군 상태 변경 성공"));
+	}
+}

--- a/src/main/java/org/example/mirimilibe/member/domain/Member.java
+++ b/src/main/java/org/example/mirimilibe/member/domain/Member.java
@@ -46,4 +46,11 @@ public class Member {
 	}
 
 	public void updatePassword(String password) { this.password = password; }
+
+	public void deleteMember() {
+		this.status = Status.INACTIVE;
+		this.nickname = "탈퇴한 회원입니다";
+		this.refreshToken = null;
+		this.password = null;
+	}
 }

--- a/src/main/java/org/example/mirimilibe/member/service/MemberService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MemberService.java
@@ -149,4 +149,13 @@ public class MemberService {
 		}
 	}
 
+	public void deleteMember(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		member.deleteMember();
+
+		memberRepository.save(member);
+	}
+
 }

--- a/src/main/java/org/example/mirimilibe/member/service/MemberService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MemberService.java
@@ -1,30 +1,25 @@
 package org.example.mirimilibe.member.service;
 
-import java.util.Date;
-import java.util.Optional;
-import java.util.function.Consumer;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
-import org.example.mirimilibe.common.Enum.MiliStatus;
-import org.example.mirimilibe.common.domain.Specialty;
-import org.example.mirimilibe.common.domain.Unit;
+
+import org.example.mirimilibe.common.Enum.Status;
+import org.example.mirimilibe.common.Enum.TermType;
+
+import org.example.mirimilibe.global.auth.dto.SignUpReq;
 import org.example.mirimilibe.global.auth.service.CoolSmsService;
 import org.example.mirimilibe.global.error.MemberErrorCode;
 import org.example.mirimilibe.global.error.SmsErrorCode;
-import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
 import org.example.mirimilibe.global.exception.MiriMiliException;
 import org.example.mirimilibe.member.domain.Member;
-import org.example.mirimilibe.member.domain.MilitaryInfo;
-import org.example.mirimilibe.member.dto.MilitaryInfoReq;
-import org.example.mirimilibe.member.dto.MilitaryInfoRes;
-import org.example.mirimilibe.member.dto.MyPageRes;
+import org.example.mirimilibe.member.domain.MemberTerm;
 import org.example.mirimilibe.member.repository.MemberRepository;
-import org.example.mirimilibe.member.repository.MilitaryInfoRepository;
-import org.example.mirimilibe.member.repository.UnitRepository;
-import org.example.mirimilibe.post.repository.SpecialtyRepository;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.example.mirimilibe.member.repository.MemberTermRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,52 +29,60 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberService {
 	private final MemberRepository memberRepository;
-	private final SpecialtyRepository specialtyRepository;
-	private final UnitRepository unitRepository;
-	private final MilitaryInfoRepository militaryInfoRepository;
-	private final StringRedisTemplate stringRedisTemplate;
 	private final BCryptPasswordEncoder passwordEncoder;
 	private final CoolSmsService coolSmsService;
+	private final MemberTermRepository memberTermRepository;
+	private final MilitaryInfoService militaryInfoService;
 
 
-	public void createMilitaryInfo(MiliStatus miliStatus, Member member) {
-		// 1. MilitaryInfo가 이미 존재하는지 확인
-		if (militaryInfoRepository.existsByMemberId(member.getId())) {
-			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_ALREADY_EXISTS);
+	public void signUp(SignUpReq signUpReq) {
+		//0. 문자 인증 여부 조회
+		/*if( !coolSmsService.isCertificationCompleted(signUpReq.phoneNumber()) ) {
+			throw new MiriMiliException(SmsErrorCode.NEED_SMS_VERIFICATION);
+		}*/
+
+		//1. 약관 동의 검사
+		if (!signUpReq.serviceAgreed() || !signUpReq.privacyPolicyAgreed()) {
+			throw new MiriMiliException(MemberErrorCode.INVALID_MEMBER_PARAMETER);
 		}
 
-		// 2. MilitaryInfo 객체 생성
-		MilitaryInfo militaryInfo=MilitaryInfo.builder()
-			.member(member)
-			.miliStatus(miliStatus)
+		checkDuplicatePhoneNumber(signUpReq.phoneNumber());
+		checkDuplicateNickname(signUpReq.nickname());
+
+		//2. 비밀번호 암호화
+		String encodedPassword = passwordEncoder.encode(signUpReq.password());
+
+		LocalDateTime now = LocalDateTime.now();
+
+		Member member = Member.builder()
+			.number(signUpReq.phoneNumber())
+			.password(encodedPassword)
+			.nickname(signUpReq.nickname())
+			.status(Status.ACTIVE)
+			.createdAt(now)
 			.build();
 
-		// 3. MilitaryInfo 저장
-		militaryInfoRepository.save(militaryInfo);
-	}
+		//3. 회원 정보 저장
+		memberRepository.save(member);
 
-	public void updateMilitaryInfo(MilitaryInfoReq militaryInfoReq, Long memberId) {
-		// 1. MilitaryInfo 객체 조회
-		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
+		//4. 약관 동의 정보 저장
+		List<MemberTerm> memberTerms = Stream.of(
+				TermType.SERVICE,
+				TermType.PRIVACY,
+				signUpReq.marketingConsentAgreed() ? TermType.MARKETING : null)
+			.filter(Objects::nonNull)
+			.map(type -> MemberTerm.builder()
+				.member(member)
+				.termType(type)
+				.agreedAt(now)
+				.build())
+			.toList();
 
-		if(militaryInfo.getMiliStatus() == MiliStatus.PRE_ENLISTED) {
-			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_ACCESS);
-		}
+		memberTermRepository.saveAll(memberTerms);
 
-		Specialty specialty = Optional.ofNullable(militaryInfoReq.specialtyId())
-			.flatMap(specialtyRepository::findById)
-			.orElse(null);
+		//5. 군 정보 생성
+		militaryInfoService.createMilitaryInfo(signUpReq.miliStatus(), member);
 
-		Unit unit = Optional.ofNullable(militaryInfoReq.unitId())
-			.flatMap(unitRepository::findById)
-			.orElse(null);
-
-		// 2. MilitaryInfoReq를 MilitaryInfo에 적용
-		applyImmutableFields(militaryInfo, militaryInfoReq, specialty, unit);
-
-		// 3. MilitaryInfo 저장
-		militaryInfoRepository.save(militaryInfo);
 	}
 
 	public void changePassword(String phoneNumber, String newPassword) {
@@ -102,52 +105,6 @@ public class MemberService {
 		memberRepository.save(member);
 	}
 
-	public MyPageRes getMilitaryInfo(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
-
-		MilitaryInfoRes militaryInfoRes=MilitaryInfoRes.fromEntity(militaryInfo);
-
-		return MyPageRes.of(militaryInfo.getMiliStatus(), member.getNickname(), member.getNumber(), militaryInfoRes);
-	}
-
-	public void updateMiliStatus(Long memberId) {
-		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
-
-		if(militaryInfo.getMiliStatus() != MiliStatus.PRE_ENLISTED) {
-			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_UPDATE);
-		}
-
-		militaryInfo.setMiliStatus(MiliStatus.ENLISTED);
-
-		militaryInfoRepository.save(militaryInfo);
-	}
-
-	public void applyImmutableFields(MilitaryInfo info, MilitaryInfoReq req, Specialty specialty, Unit unit) {
-		miliInfoValidateAndSet(info.getMiliType(), req.type(), info::setMiliType);
-		miliInfoValidateAndSet(info.getSpecialty(), specialty, info::setSpecialty);
-		miliInfoValidateAndSet(info.getUnit(), unit, info::setUnit);
-		miliInfoValidateAndSet(info.getStartDate(), req.startDate(), info::setStartDate);
-		miliInfoValidateAndSet(info.getPrivateDate(), req.privateDate(), info::setPrivateDate);
-		miliInfoValidateAndSet(info.getCorporalDate(), req.corporalDate(), info::setCorporalDate);
-		miliInfoValidateAndSet(info.getSergeantDate(), req.sergeantDate(), info::setSergeantDate);
-		miliInfoValidateAndSet(info.getDischargeDate(), req.dischargeDate(), info::setDischargeDate);
-	}
-
-	private <T> void miliInfoValidateAndSet(T currentValue, T newValue, Consumer<T> setter) {
-		if (newValue == null) {
-			return;
-		}
-		if (currentValue == null) {
-			setter.accept(newValue);
-		} else if (!currentValue.equals(newValue)) {
-			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_UPDATE);
-		}
-	}
 
 	public void deleteMember(Long memberId) {
 		Member member = memberRepository.findById(memberId)
@@ -156,6 +113,19 @@ public class MemberService {
 		member.deleteMember();
 
 		memberRepository.save(member);
+		log.info("회원 탈퇴: 사용자 ID={}", memberId);
+	}
+
+	public void checkDuplicatePhoneNumber(String phoneNumber) {
+		if (memberRepository.existsByNumber(phoneNumber)) {
+			throw new MiriMiliException(MemberErrorCode.DUPLICATE_PHONE_NUMBER);
+		}
+	}
+
+	public void checkDuplicateNickname(String nickname) {
+		if (memberRepository.existsByNickname(nickname)) {
+			throw new MiriMiliException(MemberErrorCode.DUPLICATE_NICKNAME);
+		}
 	}
 
 }

--- a/src/main/java/org/example/mirimilibe/member/service/MilitaryInfoService.java
+++ b/src/main/java/org/example/mirimilibe/member/service/MilitaryInfoService.java
@@ -1,0 +1,121 @@
+package org.example.mirimilibe.member.service;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.example.mirimilibe.common.Enum.MiliStatus;
+import org.example.mirimilibe.common.domain.Specialty;
+import org.example.mirimilibe.common.domain.Unit;
+import org.example.mirimilibe.global.error.MemberErrorCode;
+import org.example.mirimilibe.global.error.MilitaryInfoErrorCode;
+import org.example.mirimilibe.global.exception.MiriMiliException;
+import org.example.mirimilibe.member.domain.Member;
+import org.example.mirimilibe.member.domain.MilitaryInfo;
+import org.example.mirimilibe.member.dto.MilitaryInfoReq;
+import org.example.mirimilibe.member.dto.MilitaryInfoRes;
+import org.example.mirimilibe.member.dto.MyPageRes;
+import org.example.mirimilibe.member.repository.MemberRepository;
+import org.example.mirimilibe.member.repository.MilitaryInfoRepository;
+import org.example.mirimilibe.member.repository.UnitRepository;
+import org.example.mirimilibe.post.repository.SpecialtyRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MilitaryInfoService {
+	private final MemberRepository memberRepository;
+	private final MilitaryInfoRepository militaryInfoRepository;
+	private final SpecialtyRepository specialtyRepository;
+	private final UnitRepository unitRepository;
+
+
+	public void createMilitaryInfo(MiliStatus miliStatus, Member member) {
+		// 1. MilitaryInfo가 이미 존재하는지 확인
+		if (militaryInfoRepository.existsByMemberId(member.getId())) {
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_ALREADY_EXISTS);
+		}
+
+		// 2. MilitaryInfo 객체 생성
+		MilitaryInfo militaryInfo=MilitaryInfo.builder()
+			.member(member)
+			.miliStatus(miliStatus)
+			.build();
+
+		// 3. MilitaryInfo 저장
+		militaryInfoRepository.save(militaryInfo);
+	}
+
+	public void updateMilitaryInfo(MilitaryInfoReq militaryInfoReq, Long memberId) {
+		// 1. MilitaryInfo 객체 조회
+		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
+
+		if(militaryInfo.getMiliStatus() == MiliStatus.PRE_ENLISTED) {
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_ACCESS);
+		}
+
+		Specialty specialty = Optional.ofNullable(militaryInfoReq.specialtyId())
+			.flatMap(specialtyRepository::findById)
+			.orElse(null);
+
+		Unit unit = Optional.ofNullable(militaryInfoReq.unitId())
+			.flatMap(unitRepository::findById)
+			.orElse(null);
+
+		// 2. MilitaryInfoReq를 MilitaryInfo에 적용
+		applyImmutableFields(militaryInfo, militaryInfoReq, specialty, unit);
+
+		// 3. MilitaryInfo 저장
+		militaryInfoRepository.save(militaryInfo);
+	}
+
+
+	public MyPageRes getMilitaryInfo(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MiriMiliException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
+
+		MilitaryInfoRes militaryInfoRes=MilitaryInfoRes.fromEntity(militaryInfo);
+
+		return MyPageRes.of(militaryInfo.getMiliStatus(), member.getNickname(), member.getNumber(), militaryInfoRes);
+	}
+
+	public void updateMiliStatus(Long memberId) {
+		MilitaryInfo militaryInfo = militaryInfoRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_NOT_FOUND));
+
+		if(militaryInfo.getMiliStatus() != MiliStatus.PRE_ENLISTED) {
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_UPDATE);
+		}
+
+		militaryInfo.setMiliStatus(MiliStatus.ENLISTED);
+
+		militaryInfoRepository.save(militaryInfo);
+	}
+
+	public void applyImmutableFields(MilitaryInfo info, MilitaryInfoReq req, Specialty specialty, Unit unit) {
+		miliInfoValidateAndSet(info.getMiliType(), req.type(), info::setMiliType);
+		miliInfoValidateAndSet(info.getSpecialty(), specialty, info::setSpecialty);
+		miliInfoValidateAndSet(info.getUnit(), unit, info::setUnit);
+		miliInfoValidateAndSet(info.getStartDate(), req.startDate(), info::setStartDate);
+		miliInfoValidateAndSet(info.getPrivateDate(), req.privateDate(), info::setPrivateDate);
+		miliInfoValidateAndSet(info.getCorporalDate(), req.corporalDate(), info::setCorporalDate);
+		miliInfoValidateAndSet(info.getSergeantDate(), req.sergeantDate(), info::setSergeantDate);
+		miliInfoValidateAndSet(info.getDischargeDate(), req.dischargeDate(), info::setDischargeDate);
+	}
+
+	private <T> void miliInfoValidateAndSet(T currentValue, T newValue, Consumer<T> setter) {
+		if (newValue == null) {
+			return;
+		}
+		if (currentValue == null) {
+			setter.accept(newValue);
+		} else if (!currentValue.equals(newValue)) {
+			throw new MiriMiliException(MilitaryInfoErrorCode.MILITARY_INFO_CANNOT_UPDATE);
+		}
+	}
+}

--- a/src/main/java/org/example/mirimilibe/post/controller/MyPageController.java
+++ b/src/main/java/org/example/mirimilibe/post/controller/MyPageController.java
@@ -6,6 +6,8 @@ import org.example.mirimilibe.comment.dto.MyAnswerResponse;
 import org.example.mirimilibe.global.ApiResponse;
 import org.example.mirimilibe.global.auth.dto.JwtMemberDetail;
 import org.example.mirimilibe.member.domain.Member;
+import org.example.mirimilibe.member.dto.MyPageRes;
+import org.example.mirimilibe.member.service.MilitaryInfoService;
 import org.example.mirimilibe.post.dto.PostListItemResponse;
 import org.example.mirimilibe.post.service.MyPageService;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class MyPageController {
 
 	private final MyPageService myPageService;
+	private final MilitaryInfoService militaryInfoService;
 
 	@Operation(summary = "내가 작성한 게시글 목록 조회")
 	@GetMapping("/posts")
@@ -41,5 +44,16 @@ public class MyPageController {
 	) {
 		List<MyAnswerResponse> answers = myPageService.getMyAnswers(jwtMemberDetail.getMemberId());
 		return ResponseEntity.ok(ApiResponse.success(answers));
+	}
+
+	@GetMapping("/info")
+	@Operation(
+		summary = "마이페이지 정보 조회",
+		description = "사용자의 기본 정보, 군 정보를 조회하는 API입니다. <br>"
+			+ "아직 입력되지 않은 정보는 null로 반환됩니다."
+	)
+	public ResponseEntity<ApiResponse<MyPageRes>> getProfile(@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail) {
+		MyPageRes res = militaryInfoService.getMilitaryInfo(jwtMemberDetail.getMemberId());
+		return ResponseEntity.ok(ApiResponse.success(res));
 	}
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #40 

## ✨ PR 세부 내용
**회원탈퇴 시 변경되는 값들**
- status = INACTIVE
- 닉네임 = "탈퇴한 회원입니다"
- 비밀번호 = null
- refreshToken = null
- accessToken 블랙리스트에 저장

**이후 로그인 시도 시**
- 로그인 불가하도록 login 서비스 단에서 INACTIVE 검사
- 재가입은 전화번호 중복 검사에서 예외처리

**URI 바뀐 거**
회원가입
/auth/signup -> /member/signup

마이페이지 정보 조회
/member/mypage -> /mypage/info

<!-- 수정/추가한 내용을 적어주세요. -->