### PR TITLE
[REFACT]  비로그인 사용자의 게시물 조회 허용

### DIFF
--- a/src/main/java/org/example/mirimilibe/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/mirimilibe/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -47,7 +48,8 @@ public class SecurityConfig {
 					"/sms/verify", "/sms/send", "/sms/send-pwd", "/member/password").permitAll()
 				.requestMatchers("/actuator/health",
 					"/actuator/prometheus","/swagger", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll() // Swagger 허용
-				.anyRequest().authenticated() // 나머지 요청은 인증 필요
+				.requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 게시물 조회 허용
+			.anyRequest().authenticated() // 나머지 요청은 인증 필요
 			);
 
 

--- a/src/main/java/org/example/mirimilibe/post/controller/PostController.java
+++ b/src/main/java/org/example/mirimilibe/post/controller/PostController.java
@@ -81,7 +81,10 @@ public class PostController {
 		@AuthenticationPrincipal JwtMemberDetail jwtMemberDetail
 	) {
 		CommonPageResponse<PostListItemResponse> response = postService.searchPosts(keyword, pageable);
-		recentSearchService.add(jwtMemberDetail.getMemberId(), keyword);
+		// 로그인한 사용자일 경우에만 최근 검색어 저장
+		if (jwtMemberDetail != null) {
+			recentSearchService.add(jwtMemberDetail.getMemberId(), keyword);
+		}
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #46 

## ✨ PR 세부 내용
 ## Summary
  - 비로그인 사용자도 게시물을 조회할 수 있도록 보안 정책 변경
  - 서비스 접근성 향상 및 사용자 경험 개선

  ## Changes
  ### SecurityConfig.java
  - GET `/posts/**` 엔드포인트를 `permitAll()`로 설정
  - 게시물 조회(상세/리스트/검색) API에 대한 인증 요구사항 제거

  ### PostController.java
  - 검색 API에서 `jwtMemberDetail` null 체크 추가
  - 로그인한 사용자만 최근 검색어가 저장되도록 처리

<!-- 수정/추가한 내용을 적어주세요. -->