### PR TITLE
[REFACT]  비로그인 사용자 게시물 리스트/검색 조회 허용

### DIFF
--- a/src/main/java/org/example/mirimilibe/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/mirimilibe/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -37,7 +37,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/sms/verify",
 		"/sms/send",
 		"/sms/send-pwd",
-		"/member/password"
+		"/member/password",
+		"/posts/list",
+		"/posts/search"
 	);
 
 	@Override

--- a/src/main/java/org/example/mirimilibe/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/mirimilibe/global/config/SecurityConfig.java
@@ -44,12 +44,17 @@ public class SecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
 			.cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정
 			.authorizeHttpRequests(auth -> auth
+				// 인증 없이 접근 가능한 경로
 				.requestMatchers("/member/signup", "/auth/login", "/auth/checkNickname", "/auth/reissue",
 					"/sms/verify", "/sms/send", "/sms/send-pwd", "/member/password").permitAll()
 				.requestMatchers("/actuator/health",
 					"/actuator/prometheus","/swagger", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll() // Swagger 허용
-				.requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 게시물 조회 허용
-			.anyRequest().authenticated() // 나머지 요청은 인증 필요
+
+				// 게시물 리스트 및 검색 로그인 없이 허용
+				.requestMatchers(HttpMethod.GET, "/posts/list", "/posts/search").permitAll()
+
+				// 나머지 요청은 인증 필요
+				.anyRequest().authenticated()
 			);
 
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: 48
-->

## 📌 관련 이슈

- closed: #48 

## ✨ PR 세부 내용
## Summary
  - 비로그인 사용자가 게시물 리스트 및 검색 기능을 사용할 수 있도록 보안 설정 개선
  - 불필요한 인증 요구사항을 제거하여 사용자 경험 향상

  ## Changes
  ### SecurityConfig.java
  - `GET /posts/list` 및 `GET /posts/search`를 `permitAll()`로 설정
  - 기존의 와일드카드 패턴(`/posts/**`)을 구체적인 경로로 변경하여 보안 강화

  ### JwtAuthenticationFilter.java
  - `/posts/list`, `/posts/search`를 `filterPassList`에 추가
  - 해당 경로에 대해 JWT 토큰 검증을 건너뜀

  ## Why
  기존에는 모든 게시물 조회 API(`/posts/**`)가 인증 없이 허용되어 보안 취약점이 존재했습니다:
  - `/posts/answerable` (답변 가능한 게시물) - 인증 필요
  - `/posts/scrap/my` (내 스크랩) - 인증 필요
  - `/posts/{postId}` (게시물 상세) - 인증 필요

<!-- 수정/추가한 내용을 적어주세요. -->