### PR TITLE
[REFACT]  좋아요/싫어요 중복 클릭 시 토글 처리 구현

### DIFF
--- a/src/main/java/org/example/mirimilibe/comment/service/CommentLikeService.java
+++ b/src/main/java/org/example/mirimilibe/comment/service/CommentLikeService.java
@@ -43,8 +43,13 @@ public class CommentLikeService {
 		if (existing.isPresent()) {
 			CommentLike like = existing.get();
 			if (like.getType() == type) {
-				// 같은 타입으로 이미 눌렀음 → 무시 or 에러
-				throw new MiriMiliException(CommentErrorCode.ALREADY_REACTED);
+				// 같은 타입으로 다시 누르면 취소 (삭제)
+				commentLikeRepository.delete(like);
+				// 마지막 활동 시간 업데이트 및 베스트 답변 재계산
+				Long postId = comment.getPost().getId();
+				rankingService.updateLastActivity(postId);
+				rankingService.updateBestAnswersForPost(postId);
+				return; // 알림 처리 없이 종료
 			} else {
 				// 다른 타입으로 변경
 				like.setType(type);

--- a/src/main/java/org/example/mirimilibe/post/service/PostLikeService.java
+++ b/src/main/java/org/example/mirimilibe/post/service/PostLikeService.java
@@ -43,7 +43,11 @@ public class PostLikeService {
 		if (existing.isPresent()) {
 			PostLike like = existing.get();
 			if (like.getType() == type) {
-				throw new MiriMiliException(PostErrorCode.ALREADY_REACTED);
+				// 같은 타입으로 다시 누르면 취소 (삭제)
+				postLikeRepository.delete(like);
+				// 마지막 활동 시간 업데이트
+				rankingService.updateLastActivity(postId);
+				return; // 알림 처리 없이 종료
 			}
 			like.setType(type); // 상태 변경
 		} else {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #82 

## ✨ PR 세부 내용
## Summary
  - 게시물/댓글 좋아요/싫어요 중복 클릭 시 에러 반환 대신 취소(토글) 처리
  - PostLikeService, CommentLikeService 동일하게 적용

  ## Changes
  - 같은 타입 재클릭 시 기존 반응 삭제
  - 다른 타입 클릭 시 타입 변경 (기존 로직 유지)


<!-- 수정/추가한 내용을 적어주세요. -->